### PR TITLE
fix crash and controller startup

### DIFF
--- a/RobotServer/controllers/http_robot/http_robot.py
+++ b/RobotServer/controllers/http_robot/http_robot.py
@@ -115,13 +115,6 @@ if __name__ == "__main__":
     robot = Robot()
     timestep = int(robot.getBasicTimeStep())
 
-    # If the controller started before the supervisor inserted all of the args,
-    # just run an empty simulator loop so we don't block the simulation while
-    # we wait for the supervisor to restart this controller
-    if sys.argv[-1] != "READY":
-        while robot.step(timestep) != -1:
-            pass
-
     print("Starting flask server")
     device_map = build_device_map(robot)
     threading.Thread(target=start_flask).start()
@@ -131,5 +124,3 @@ if __name__ == "__main__":
     while robot.step(timestep) != -1:
         time.sleep(timestep / 1000)
     print("Finished")
-
-

--- a/RobotServer/controllers/http_supervisor/http_supervisor.py
+++ b/RobotServer/controllers/http_supervisor/http_supervisor.py
@@ -60,14 +60,9 @@ def spawnRobot(robotTemplate):
     controllerArgs.insertMFString(-1, str(nextRobotId))
     controllerArgs.insertMFString(-1, tcpPort)
 
-    # Insert a final controller arg to let the controller know it's ready.
-    # The controller may have already started before any args were set,
-    # but this will signal it to wait, without it having to know how many
-    # args to expect.
-    controllerArgs.insertMFString(-1, "READY")
-
-    # Restart the controller
-    newRobot.restartController()
+    # Finally set the controller
+    controllerField = newRobot.getField("controller")
+    controllerField.setSFString("http_robot")
 
     return tcpPort
 

--- a/RobotServer/objects/HttpRobotTemplate.wbo
+++ b/RobotServer/objects/HttpRobotTemplate.wbo
@@ -157,5 +157,6 @@ DEF RobotTemplate Robot {
       0 0.2 0
     ]
   }
-  controller "http_robot"
+  controller ""
+  synchronization FALSE
 }

--- a/RobotServer/worlds/frc_rectangle.wbt
+++ b/RobotServer/worlds/frc_rectangle.wbt
@@ -20,4 +20,5 @@ DEF Supervisor Robot {
   rotation 1 0 0 1.5707963267948966
   controller "http_supervisor"
   supervisor TRUE
+  synchronization FALSE
 }


### PR DESCRIPTION
* Fix crash by using asynchronous mode for controllers. This should have no tangible effect since our controllers were already effectively asynchronous with their background threads accepting requests.
* Fix controller startup by assigning the robot `controller` after setting `controllerArgs` so we don't require the "READY" arg. If we want different controllers for different robots, we can specify this elsewhere, like in the spawn request.