### PR TITLE
Increase bounding box to outside bumpers

### DIFF
--- a/RobotServer/objects/HttpRobotTemplate.wbo
+++ b/RobotServer/objects/HttpRobotTemplate.wbo
@@ -1,7 +1,7 @@
 #VRML_OBJ R2021a utf8
 DEF RobotTemplate Robot {
-  translation -4.040465635521352e-07 5.542122743965039e-05 -0.0004979818870471751
-  rotation 0.9999560222553209 0.00937823892755729 -4.679672949339127e-05 -0.014762789747290086
+  translation -4.0439704099407676e-07 5.5423774848933904e-05 -0.0004974537671817198
+  rotation 0.9999560176012507 0.009378735165413987 -4.6794704668699246e-05 -0.014762646787621006
   children [
     Transform {
       translation 0 0 0.2
@@ -33,8 +33,8 @@ DEF RobotTemplate Robot {
       ]
     }
     MotorizedRobotWheel {
-      translation -0.3683 0.35 0.0762
-      rotation -1 0 0 2.9802322387695313e-08
+      translation -0.3683 0.34999999999992143 0.07619999999999884
+      rotation -0.9920649343772965 -0.12571284275453493 -0.0018566490093449865 2.9802322387695313e-08
       name "FL Wheel"
       device [
         PositionSensor {
@@ -47,8 +47,8 @@ DEF RobotTemplate Robot {
       ]
     }
     MotorizedRobotWheel {
-      translation -0.368275 0 0.071375
-      rotation 1 0 0 2.9802322387695313e-08
+      translation -0.368275 6.652444111222356e-14 0.07137500000000098
+      rotation 0.9935374938348875 -0.11349201999141713 -0.0016762286713731323 2.9802322387695313e-08
       name "CL Wheel"
       device [
         PositionSensor {
@@ -61,8 +61,8 @@ DEF RobotTemplate Robot {
       ]
     }
     MotorizedRobotWheel {
-      translation 0.3683 0.35 0.0761856
-      rotation -1 0 0 2.9802322387695313e-08
+      translation 0.3683 0.3499999999999246 0.0761855999999989
+      rotation -0.9924557449524966 -0.12259003316380931 -0.0018105467906594584 2.9802322387695313e-08
       name "FR Wheel"
       device [
         PositionSensor {
@@ -75,8 +75,8 @@ DEF RobotTemplate Robot {
       ]
     }
     MotorizedRobotWheel {
-      translation 0.3683 0 0.0711856
-      rotation 1 0 0 2.9802322387695313e-08
+      translation 0.3683 6.9500997898104e-14 0.07118560000000103
+      rotation 0.9931913930698782 -0.11648131651422089 -0.0017203589823357038 2.9802322387695313e-08
       name "CR Wheel"
       device [
         PositionSensor {
@@ -90,7 +90,7 @@ DEF RobotTemplate Robot {
     }
     MotorizedRobotWheel {
       translation -0.3683 -0.35 0.0761856
-      rotation 0.3820545503726815 0.9239747841475688 0.01746192426342322 2.768040321278569e-13
+      rotation 0.3654470668080611 0.930665639808804 0.01760421087847893 2.7480561108531835e-13
       name "BL wheel"
       device [
         PositionSensor {
@@ -104,7 +104,7 @@ DEF RobotTemplate Robot {
     }
     MotorizedRobotWheel {
       translation 0.3683 -0.35 0.0761856
-      rotation 0.6515714810172186 -0.7585728992063844 -0.004664945299660692 6.115458936643195e-15
+      rotation -0.28075487062088067 -0.9597665035497732 -0.00499612714966866 4.819454123219197e-15
       name "BR wheel"
       device [
         PositionSensor {
@@ -159,6 +159,7 @@ DEF RobotTemplate Robot {
   name "basic robot"
   boundingObject Transform {
     translation 0 0 0.8128
+    scale 1.25 1.15 1
     children [
       Shape {
         appearance PBRAppearance {
@@ -179,6 +180,6 @@ DEF RobotTemplate Robot {
   }
   controller ""
   supervisor TRUE
-  linearVelocity -6.928213244258853e-11 -2.7522984001442463e-10 3.957892216239998e-06
-  angularVelocity -8.615410374221726e-08 -4.061387573926581e-08 -1.9156730020366594e-10
+  linearVelocity -7.76001645857984e-13 3.871387850915973e-12 1.6730189010560386e-07
+  angularVelocity -1.1271680187759716e-08 1.8645837245750233e-12 1.5292697720574208e-11
 }

--- a/RobotServer/worlds/robot_editor.wbt
+++ b/RobotServer/worlds/robot_editor.wbt
@@ -3,8 +3,8 @@ WorldInfo {
 }
 Viewpoint {
   fieldOfView 1.0472
-  orientation -0.9995805302502716 -0.005030973417480489 -0.02852109484326566 5.038995302675764
-  position -0.12978731163500842 -4.389054553920054 2.3369992239119877
+  orientation -0.631968504168306 0.45513012200531855 0.6272737694043148 4.49831691886814
+  position -3.9001049877737226 0.3352968839085918 1.868327331877683
 }
 Solid {
   rotation 1 0 0 1.57079632679
@@ -37,8 +37,8 @@ DirectionalLight {
   castShadows TRUE
 }
 DEF RobotTemplate Robot {
-  translation -4.040465635521352e-07 5.542122743965039e-05 -0.0004979818870471751
-  rotation 0.9999560222553209 0.00937823892755729 -4.679672949339127e-05 -0.014762789747290086
+  translation -4.0439704099407676e-07 5.5423774848933904e-05 -0.0004974537671817198
+  rotation 0.9999560176012507 0.009378735165413987 -4.6794704668699246e-05 -0.014762646787621006
   children [
     Transform {
       translation 0 0 0.2
@@ -70,8 +70,8 @@ DEF RobotTemplate Robot {
       ]
     }
     MotorizedRobotWheel {
-      translation -0.3683 0.35 0.0762
-      rotation -1 0 0 2.9802322387695313e-08
+      translation -0.3683 0.34999999999992143 0.07619999999999884
+      rotation -0.9920649343772965 -0.12571284275453493 -0.0018566490093449865 2.9802322387695313e-08
       name "FL Wheel"
       device [
         PositionSensor {
@@ -84,8 +84,8 @@ DEF RobotTemplate Robot {
       ]
     }
     MotorizedRobotWheel {
-      translation -0.368275 0 0.071375
-      rotation 1 0 0 2.9802322387695313e-08
+      translation -0.368275 6.652444111222356e-14 0.07137500000000098
+      rotation 0.9935374938348875 -0.11349201999141713 -0.0016762286713731323 2.9802322387695313e-08
       name "CL Wheel"
       device [
         PositionSensor {
@@ -98,8 +98,8 @@ DEF RobotTemplate Robot {
       ]
     }
     MotorizedRobotWheel {
-      translation 0.3683 0.35 0.0761856
-      rotation -1 0 0 2.9802322387695313e-08
+      translation 0.3683 0.3499999999999246 0.0761855999999989
+      rotation -0.9924557449524966 -0.12259003316380931 -0.0018105467906594584 2.9802322387695313e-08
       name "FR Wheel"
       device [
         PositionSensor {
@@ -112,8 +112,8 @@ DEF RobotTemplate Robot {
       ]
     }
     MotorizedRobotWheel {
-      translation 0.3683 0 0.0711856
-      rotation 1 0 0 2.9802322387695313e-08
+      translation 0.3683 6.9500997898104e-14 0.07118560000000103
+      rotation 0.9931913930698782 -0.11648131651422089 -0.0017203589823357038 2.9802322387695313e-08
       name "CR Wheel"
       device [
         PositionSensor {
@@ -127,7 +127,7 @@ DEF RobotTemplate Robot {
     }
     MotorizedRobotWheel {
       translation -0.3683 -0.35 0.0761856
-      rotation 0.3820545503726815 0.9239747841475688 0.01746192426342322 2.768040321278569e-13
+      rotation 0.3654470668080611 0.930665639808804 0.01760421087847893 2.7480561108531835e-13
       name "BL wheel"
       device [
         PositionSensor {
@@ -141,7 +141,7 @@ DEF RobotTemplate Robot {
     }
     MotorizedRobotWheel {
       translation 0.3683 -0.35 0.0761856
-      rotation 0.6515714810172186 -0.7585728992063844 -0.004664945299660692 6.115458936643195e-15
+      rotation -0.28075487062088067 -0.9597665035497732 -0.00499612714966866 4.819454123219197e-15
       name "BR wheel"
       device [
         PositionSensor {
@@ -196,6 +196,7 @@ DEF RobotTemplate Robot {
   name "basic robot"
   boundingObject Transform {
     translation 0 0 0.8128
+    scale 1.25 1.15 1
     children [
       Shape {
         appearance PBRAppearance {
@@ -216,6 +217,6 @@ DEF RobotTemplate Robot {
   }
   controller ""
   supervisor TRUE
-  linearVelocity -6.928213244258853e-11 -2.7522984001442463e-10 3.957892216239998e-06
-  angularVelocity -8.615410374221726e-08 -4.061387573926581e-08 -1.9156730020366594e-10
+  linearVelocity -7.76001645857984e-13 3.871387850915973e-12 1.6730189010560386e-07
+  angularVelocity -1.1271680187759716e-08 1.8645837245750233e-12 1.5292697720574208e-11
 }


### PR DESCRIPTION
This should help stop the wheels from getting stuck outside the field because now the robots bounding box is where the bumpers are:
```
boundingObject Transform {
    translation 0 0 0.8128
    scale 1.25 1.15 1 <<<<<< only real change
    children [
```
![robot_editor](https://user-images.githubusercontent.com/399279/106693914-545add80-658c-11eb-9943-de0629f01327.png)

