### PR TITLE
Support multiple motor modes

### DIFF
--- a/RobotServer/controllers/http_robot/http_robot.py
+++ b/RobotServer/controllers/http_robot/http_robot.py
@@ -28,7 +28,7 @@ line_map = {}
 motor_requests = {}
 
 class MotorModes(enum.Enum):
-    RAW = 0
+    POWER = 0
     VELOCITY = 1
     POSITION = 2
 
@@ -412,7 +412,7 @@ def update_motors():
                 motor.setVelocity(float(value * motor.getMaxVelocity()))
             elif mode == MotorModes.POSITION:
                 motor.setPosition(float(value))
-            elif mode == MotorModes.RAW:
+            elif mode == MotorModes.POWER:
                 motor.setForce(float(value * motor.getMaxTorque()))
             else:
                 raise Exception(f"Unhandled motor mode {mode}")


### PR DESCRIPTION
raw power (percent throttle), velocity (what we used to only support) and position.

This required a change to how we set motors values in the sim because the raw power setting was instantaneous (as opposed to continuously applied). Before this meant the power would only be applied when the put_motors call was made to the webserver, but the sim runs at a faster cadence then that and we didn't get the expected behavior (the motors often had no force applied even if the java code meant to apply it continuously). 

So now instead the put_motors doesn't apply anything itself, but rather saves the motor request to a dictionary that will then be applied in the main robot loop continuously.
