### PR TITLE
fix getPosition race condition

### DIFF
--- a/RobotServer/controllers/http_robot/http_robot.py
+++ b/RobotServer/controllers/http_robot/http_robot.py
@@ -119,7 +119,7 @@ def put_motors():
                 "Roll": imu.getRollPitchYaw()[2],
                 "Pitch": imu.getRollPitchYaw()[1],
                 "Yaw": imu.getRollPitchYaw()[0],
-                "YawVelocity" : gyro.getValues()[2]
+                "YawVelocity" : gyro.getValues()[2] if gyro else ""
             }
         }
         for imu, gyro in zip_longest(device_map["IMUs"].values(), device_map["Gyros"].values())
@@ -127,9 +127,9 @@ def put_motors():
 
     # return exact robot world pose for debugging
     robot_node = robot.getSelf()
-    position = robot_node.getPosition()
-    rotation = robot_node.getOrientation()
-    yaw = math.degrees(math.atan2(rotation[0], rotation[1])) % 360
+    pose = robot_node.getPose()
+    position = (pose[3], pose[7], pose[11])
+    yaw = math.degrees(math.atan2(pose[0], pose[1])) % 360
 
     # simulation time is reported in seconds
     time = robot.getTime()

--- a/RobotServer/controllers/http_robot/http_robot.py
+++ b/RobotServer/controllers/http_robot/http_robot.py
@@ -119,7 +119,7 @@ def put_motors():
                 "Roll": imu.getRollPitchYaw()[2],
                 "Pitch": imu.getRollPitchYaw()[1],
                 "Yaw": imu.getRollPitchYaw()[0],
-                "YawVelocity" : gyro.getValues()[2] if gyro else ""
+                "YawVelocity" : gyro.getValues()[2] if gyro else 0
             }
         }
         for imu, gyro in zip_longest(device_map["IMUs"].values(), device_map["Gyros"].values())


### PR DESCRIPTION
The race condition (mentioned in the [docs](https://cyberbotics.com/doc/reference/supervisor?tab-language=python#wb_supervisor_node_get_pose) as "The returned pointers are valid during one time step only as memory will be deallocated at the next time step") only exists in `getPosition` and `getOrientation` because they allocate new memory. However calling `getPose` doesn't have this same issue.