### PR TITLE
Virtual solenoid support

### DIFF
--- a/RobotServer/controllers/http_robot/robot/motor_requests.py
+++ b/RobotServer/controllers/http_robot/robot/motor_requests.py
@@ -5,6 +5,11 @@ class MotorModes(enum.Enum):
     POWER = 0
     VELOCITY = 1
     POSITION = 2
+    VIRTUAL_SOLENOID = 3
+
+class SolenoidPositions(enum.Enum):
+    ON = 'on'
+    OFF = 'off'
 
 
 def apply_motor_requests(
@@ -31,6 +36,11 @@ def update_motors(device_map: dict, motor_requests: dict) -> None:
             motor.setVelocity(float(value * motor.getMaxVelocity()))
         elif mode == MotorModes.POSITION:
             motor.setPosition(float(value))
+        elif mode == MotorModes.VIRTUAL_SOLENOID:
+            if value == SolenoidPositions.ON:
+                motor.setPosition(motor.getMaxPosition())
+            else:
+                motor.setPosition(motor.getMinPosition())
         elif mode == MotorModes.POWER:
             motor.setForce(float(value * motor.getMaxTorque()))
         else:

--- a/RobotServer/controllers/http_robot/robot/motor_requests.py
+++ b/RobotServer/controllers/http_robot/robot/motor_requests.py
@@ -37,10 +37,15 @@ def update_motors(device_map: dict, motor_requests: dict) -> None:
         elif mode == MotorModes.POSITION:
             motor.setPosition(float(value))
         elif mode == MotorModes.VIRTUAL_SOLENOID:
-            if value == SolenoidPositions.ON:
+            target_position = SolenoidPositions[value.upper()]
+            # Set the max velocity that the positional pid can use
+            motor.setVelocity(motor.getMaxVelocity())
+            if target_position == SolenoidPositions.ON:
                 motor.setPosition(motor.getMaxPosition())
-            else:
+            elif target_position == SolenoidPositions.OFF:
                 motor.setPosition(motor.getMinPosition())
+            else:
+                raise ValueError("Unknown solenoid position: " + target_position)
         elif mode == MotorModes.POWER:
             motor.setForce(float(value * motor.getMaxTorque()))
         else:


### PR DESCRIPTION
Added a new way of setting webots motors that treats them like an on/off solenoid that goes to max or min position based on being set on/off in the motor requests:

```
curl --location --request PUT 'localhost:10002/motors' \
--header 'Content-Type: application/json' \
--data-raw '{
    "motors": [
        {
            "id": "Solenoid1",
            "val": "ON",
            "mode": "VIRTUAL_SOLENOID"
        }
    ]
}'
```

https://user-images.githubusercontent.com/399279/153729989-b6740d0f-fdf1-4c89-91eb-7440fa436590.mp4




There will be a corresponding change in the common lib to start sending these values out of the solenoids.