### PR TITLE
Feature/Report position on the same device id as a motor

### DIFF
--- a/RobotServer/controllers/http_robot/robot/motor_requests.py
+++ b/RobotServer/controllers/http_robot/robot/motor_requests.py
@@ -35,6 +35,7 @@ def update_motors(device_map: dict, motor_requests: dict) -> None:
             motor.setPosition(float("inf"))
             motor.setVelocity(float(value * motor.getMaxVelocity()))
         elif mode == MotorModes.POSITION:
+            motor.setVelocity(motor.getMaxVelocity())
             motor.setPosition(float(value))
         elif mode == MotorModes.VIRTUAL_SOLENOID:
             target_position = SolenoidPositions[value.upper()]

--- a/RobotServer/controllers/http_robot/robot/sensors.py
+++ b/RobotServer/controllers/http_robot/robot/sensors.py
@@ -43,6 +43,15 @@ def get_sensors_data(device_map, robot) -> list:
         for position_sensor in device_map["PositionSensors"].values()
     ]
 
+    motor_encoder_values = [
+        {
+            # report motor encoder position with CAN prefix
+            "ID": get_device_id(motor).replace("Motor", "CAN"),
+            "Payload": {"EncoderTicks": motor.getPositionSensor().getValue()},
+        }
+        for motor in device_map["Motors"].values() if motor.getPositionSensor() is not None
+    ]
+
     position_sensor_limit_switch_values = []
     for position_sensor_limit_switch in device_map[
         "PositionSensorLimitSwitch"
@@ -79,7 +88,7 @@ def get_sensors_data(device_map, robot) -> list:
                 "Roll": imu.getRollPitchYaw()[2],
                 "Pitch": imu.getRollPitchYaw()[1],
                 "Yaw": imu.getRollPitchYaw()[0],
-                "YawVelocity": gyro.getValues()[2],
+                "YawVelocity": gyro.getValues()[2] if gyro is not None else 0.0,
             },
         }
         for imu, gyro in zip_longest(
@@ -92,6 +101,7 @@ def get_sensors_data(device_map, robot) -> list:
             distance_sensor_values,
             bumper_touch_sensor_values,
             position_sensor_values,
+            motor_encoder_values,
             position_sensor_limit_switch_values,
             imu_sensor_values,
         )

--- a/RobotServer/controllers/http_robot/tests/test_http_robot.py
+++ b/RobotServer/controllers/http_robot/tests/test_http_robot.py
@@ -1,5 +1,5 @@
 import json
-from unittest.mock import Mock
+from unittest.mock import MagicMock, Mock
 
 from pytest import mark
 
@@ -34,7 +34,9 @@ def test_put_motors__invalid_motor(test_app):
 def test_put_motors__default_set(test_app):
     motor_id = "Motor1"
 
-    test_app.device_map["Motors"][motor_id] = Mock()
+    motor_mock = MagicMock()
+    motor_mock.getPositionSensor.return_value = None
+    test_app.device_map["Motors"][motor_id] = motor_mock
 
     response = test_app.test_client.put(
         "/motors",
@@ -49,7 +51,9 @@ def test_put_motors__default_set(test_app):
 def test_put_motors__set_position(test_app):
     motor_id = "Motor1"
 
-    test_app.device_map["Motors"][motor_id] = Mock()
+    motor_mock = MagicMock()
+    motor_mock.getPositionSensor.return_value = None
+    test_app.device_map["Motors"][motor_id] = motor_mock
 
     response = test_app.test_client.put(
         "/motors",


### PR DESCRIPTION
This is useful for the swerve mechanism where we want to be able to simulate both motor controller's internal encoder connection in addition to a secondary encoder.