### PR TITLE
add generic text proto

### DIFF
--- a/RobotServer/protos/common/Text.proto
+++ b/RobotServer/protos/common/Text.proto
@@ -1,0 +1,128 @@
+#VRML_OBJ R2022a utf8
+
+PROTO Text [
+  field SFString   name        "text"
+  field SFVec3f    translation 0 0 0
+  field SFRotation rotation    1 0 0 0
+  field SFVec2f    size        1 1
+  field SFInt32    dpi         8
+  field SFString   text        "TEXT"
+  field SFString   font        "Arial"
+  field SFInt32    fontSize    800
+  field SFColor    textColor   0 0 0
+  field SFNode     appearance  PBRAppearance {
+    baseColor 1 1 1
+    metalness 0
+    roughness 1
+  }
+]
+{
+  %{
+    local gd = require("gd")
+    local debug = require("debug")
+    local os = require('os')
+
+    function roundUpToPowerOf2(x)
+      return math.pow(2, math.ceil(math.log(x)/math.log(2)))
+    end
+
+    -- calculate the image size
+    local inchesPerMeter = 39.3701
+    local widthInches = fields.size.value.x * inchesPerMeter
+    local heightInches = fields.size.value.y * inchesPerMeter
+    local imageWidth = roundUpToPowerOf2(widthInches * fields.dpi.value)
+    local imageHeight = roundUpToPowerOf2(heightInches * fields.dpi.value)
+    local hdpi = math.floor(imageWidth / widthInches)
+    local vdpi = math.floor(imageHeight / heightInches)
+
+    -- serialize all the params into a name that uniquely identifies this image
+    local baseColor = fields.appearance.value.fields.baseColor.value
+    name = debug.getinfo(1, 'S').source -- get the name of the current file
+    name = name
+      .. '.' .. fields.text.value
+      .. '.' .. fields.font.value
+      .. '.' .. fields.fontSize.value
+      .. '.' .. fields.textColor.value.r
+      .. '.' .. fields.textColor.value.g
+      .. '.' .. fields.textColor.value.b
+      .. '.' .. baseColor.r
+      .. '.' .. baseColor.g
+      .. '.' .. baseColor.b
+      .. '.' .. imageWidth
+      .. '.' .. imageHeight
+      .. '.' .. hdpi
+      .. '.' .. vdpi
+    name = name .. '.png'
+
+    -- create the file if it doesn't exist already
+    local file = io.open(name, 'r')
+    if file then
+      file:close()
+    else
+      -- construct an image
+      local im = gd.createTrueColor(imageWidth, imageHeight)
+      local textColor = im:colorAllocate(
+        math.floor(fields.textColor.value.r * 255),
+        math.floor(fields.textColor.value.g * 255),
+        math.floor(fields.textColor.value.b * 255)
+      )
+      local bgColor = im:colorAllocate(
+        math.floor(baseColor.r * 255),
+        math.floor(baseColor.g * 255),
+        math.floor(baseColor.b * 255)
+      )
+
+      -- draw text once to get dimensions
+      gd.fontCacheSetup()
+      local llx, lly, lrx, lry, urx, ury, ulx, uly = im:stringFTEx(bgColor, fields.font.value, fields.fontSize.value, 0, 0, 0, fields.text.value, { hdpi=hdpi, vdpi=vdpi })
+
+      -- fill the background color
+      im:filledRectangle(0, 0, imageWidth - 1, imageHeight - 1, bgColor)
+
+      -- draw text for real, centered
+      local textX = (imageWidth - lrx) / 2
+      local textY = (imageHeight - ury) / 2
+      im:stringFTEx(textColor, fields.font.value, fields.fontSize.value, 0, textX, textY, fields.text.value, { hdpi=hdpi, vdpi=vdpi })
+
+      -- save the image to file
+      im:png(name)
+      gd.fontCacheShutdown()
+    end
+  }%
+  Transform {
+    translation IS translation
+    rotation IS rotation
+    children [
+      Shape {
+        appearance PBRAppearance {
+          baseColorMap ImageTexture {
+            url [ %{= '"' .. context.temporary_files_path .. name .. '"' }% ]
+            repeatS FALSE
+            repeatT FALSE
+            filtering 0
+          }
+
+          # unpack all the remaining appearance values
+          transparency %{=fields.appearance.value.fields.transparency.value}%
+          roughness %{=fields.appearance.value.fields.roughness.value}%
+          metalness %{=fields.appearance.value.fields.metalness.value}%
+          IBLStrength %{=fields.appearance.value.fields.IBLStrength.value}%
+          emissiveColor %{=fields.appearance.value.fields.emissiveColor.value.r}% %{=fields.appearance.value.fields.emissiveColor.value.g}% %{=fields.appearance.value.fields.emissiveColor.value.b}%
+          emissiveIntensity %{=fields.appearance.value.fields.emissiveIntensity.value}%
+          %{ if fields.appearance.value.fields.textureTransform.value then }%
+            textureTransform TextureTransform {
+              center %{=fields.appearance.value.fields.textureTransform.value.fields.center.value.x}% %{=fields.appearance.value.fields.textureTransform.value.fields.center.value.y}%
+              rotation %{=fields.appearance.value.fields.textureTransform.value.fields.rotation.value}%
+              scale %{=fields.appearance.value.fields.textureTransform.value.fields.scale.value.x}% %{=fields.appearance.value.fields.textureTransform.value.fields.scale.value.y}%
+              translation %{=fields.appearance.value.fields.textureTransform.value.fields.translation.value.x}% %{=fields.appearance.value.fields.textureTransform.value.fields.translation.value.y}%
+            }
+          %{ end }%
+        }
+        geometry Plane {
+          size IS size
+        }
+        castShadows FALSE
+      }
+    ]
+  }
+}

--- a/RobotServer/protos/common/Text.proto
+++ b/RobotServer/protos/common/Text.proto
@@ -1,7 +1,6 @@
 #VRML_OBJ R2022a utf8
 
 PROTO Text [
-  field SFString   name        "text"
   field SFVec3f    translation 0 0 0
   field SFRotation rotation    1 0 0 0
   field SFVec2f    size        1 1
@@ -114,7 +113,8 @@ PROTO Text [
               center %{=fields.appearance.value.fields.textureTransform.value.fields.center.value.x}% %{=fields.appearance.value.fields.textureTransform.value.fields.center.value.y}%
               rotation %{=fields.appearance.value.fields.textureTransform.value.fields.rotation.value}%
               scale %{=fields.appearance.value.fields.textureTransform.value.fields.scale.value.x}% %{=fields.appearance.value.fields.textureTransform.value.fields.scale.value.y}%
-              translation %{=fields.appearance.value.fields.textureTransform.value.fields.translation.value.x}% %{=fields.appearance.value.fields.textureTransform.value.fields.translation.value.y}%
+              # adding translation here causes webots to not give this object axis handles, so it's ignored
+              # we don't need it here anyway since the entire object is encapsulated in a transform
             }
           %{ end }%
         }

--- a/RobotServer/protos/robot/Bumper.proto
+++ b/RobotServer/protos/robot/Bumper.proto
@@ -1,4 +1,4 @@
-#VRML_SIM R2021a utf8
+#VRML_SIM R2022a utf8
 
 PROTO Bumper [
   field SFVec3f    translation 0 0 0
@@ -12,7 +12,13 @@ PROTO Bumper [
   }
   field SFString   teamNumber  "488"
   field SFNode     appearance  PBRAppearance {
-    baseColor 1 0 0
+    baseColor 0.7 0 0
+    metalness 0
+    roughness 1
+    textureTransform TextureTransform {
+      center -0.5 0
+      scale 0.5 1
+    }
   }
 ]
 {
@@ -62,44 +68,6 @@ PROTO Bumper [
     rightBox.y = math.abs(rightBox.y1 - rightBox.y2)
     rightBox.xTranslation = - fields.size.value.x / 2 - fields.bumperWidth.value / 2
     rightBox.yTranslation = 0
-
-    -- build the texture with team number
-    local gd = require("gd")
-    local debug = require("debug")
-    local os = require('os')
-    local wbrandom = require('wbrandom')
-    wbrandom.seed(os.clock() + os.time())
-    imageWidth = 256
-    imageHeight = 64
-    local im = gd.createTrueColor(imageWidth, imageHeight)
-    bColor = fields.appearance.value.fields.baseColor.value
-    bgColor = im:colorAllocate(bColor.r * 255, bColor.g * 255, bColor.b * 255)
-    im:filledRectangle(0, 0, imageWidth - 1, imageHeight - 1, bgColor)
-    -- add the text in the texture
-    textColor = im:colorAllocate(255, 255, 255)
-    gd.fontCacheSetup()
-    -- calculate dpi so decal size is static
-    hdpi = 200 * (0.838 / frontDecal.x)
-    vdpi = 160 * (0.127 / fields.size.value.z)
-    -- draw once to get dimensions
-    llx, lly, lrx, lry, urx, ury, ulx, uly = im:stringFTEx(bgColor, "Impact", 20, 0, 0, 0, fields.teamNumber.value, { hdpi=hdpi, vdpi=vdpi })
-    -- draw for real, centered
-    textX = (imageWidth - lrx) / 2
-    textY = (imageHeight - ury) / 2
-    im:stringFTEx(textColor, "Impact", 20, 0, textX, textY, fields.teamNumber.value, { hdpi=hdpi, vdpi=vdpi })
-
-    -- save the image in a png file
-    local name = debug.getinfo(1,'S').source  -- get the name of the current file
-    name = name .. wbrandom.integer(0, 100000)  -- add a random number to reduce name clashes
-    local i = 0  -- make sure the file does not already exist
-    local file = io.open(name .. i .. ".png", "r")
-    while file do
-      file:close()
-      i = i + 1
-      file = io.open(name .. i .. ".png", "r")
-    end
-    im:png(name .. i .. ".png")
-    gd.fontCacheShutdown()
   }%
 
   Solid {
@@ -107,24 +75,16 @@ PROTO Bumper [
     translation IS translation
     rotation IS rotation
     children [
-      Solid {
-        name "front-decal"
+      Text {
+        size %{=frontDecal.x}% %{=fields.size.value.z}%
         translation %{=frontDecal.xTranslation}% %{=frontDecal.yTranslation}% 0
-        children [
-          Shape {
-            appearance PBRAppearance {
-              baseColorMap ImageTexture {
-                url [ %{= '"' .. context.temporary_files_path .. name .. i .. '.png"' }% ]
-              }
-              textureTransform TextureTransform {
-                rotation 3.1415927
-              }
-            }
-            geometry Plane {
-              size %{=frontDecal.x}% %{=fields.size.value.z }%
-            }
-          }
-        ]
+        rotation 0 0.707107 0.707107 3.14159
+        text IS teamNumber
+        textColor 0.9 0.9 0.9
+        font "Impact"
+        fontSize 250
+        dpi 16
+        appearance IS appearance
       }
       Solid {
         name "front-bumper"

--- a/RobotServer/protos/vision/AprilTag16h5Panel.proto
+++ b/RobotServer/protos/vision/AprilTag16h5Panel.proto
@@ -7,53 +7,6 @@ PROTO AprilTag16h5Panel [
   field SFInt32    aprilTagId  0
 ]
 {
-  %{
-    -- construct the dynamic ID label
-    text = "ID " .. fields.aprilTagId.value
-
-    -- build the texture
-    local gd = require("gd")
-    local debug = require("debug")
-    local os = require('os')
-    local wbrandom = require('wbrandom')
-    wbrandom.seed(os.clock() + os.time())
-    imageWidth = 256
-    imageHeight = 128
-    local im = gd.createTrueColor(imageWidth, imageHeight)
-    bgColor = im:colorAllocate(255, 255, 255)
-    im:filledRectangle(0, 0, imageWidth - 1, imageHeight - 1, bgColor)
-    -- calculate dpi so decal size is static
-    inchesPerMeter = 39.3701
-    labelWidthInches = 2
-    labelHeightInches = 0.75
-    labelWidthMeters = 0.0254 * labelWidthInches
-    labelHeightMeters = 0.0254 * labelHeightInches
-    hdpi = imageWidth / labelWidthInches
-    vdpi = imageHeight / labelHeightInches
-    -- draw text once to get dimensions
-    gd.fontCacheSetup()
-    font = "Arial"
-    fontSize = 60
-    llx, lly, lrx, lry, urx, ury, ulx, uly = im:stringFTEx(bgColor, font, fontSize, 0, 0, 0, text, { hdpi=hdpi, vdpi=vdpi })
-    -- draw text for real, centered
-    textX = (imageWidth - lrx) / 2
-    textY = (imageHeight - ury) / 2
-    textColor = im:colorAllocate(0, 0, 0)
-    im:stringFTEx(textColor, font, fontSize, 0, textX, textY, text, { hdpi=hdpi, vdpi=vdpi })
-
-    -- save the image in a png file
-    local name = debug.getinfo(1,'S').source  -- get the name of the current file
-    name = name .. wbrandom.integer(0, 100000)  -- add a random number to reduce name clashes
-    local i = 0  -- make sure the file does not already exist
-    local file = io.open(name .. i .. ".png", "r")
-    while file do
-      file:close()
-      i = i + 1
-      file = io.open(name .. i .. ".png", "r")
-    end
-    im:png(name .. i .. ".png")
-    gd.fontCacheShutdown()
-  }%
   Solid {
     name IS name
     translation IS translation
@@ -78,23 +31,17 @@ PROTO AprilTag16h5Panel [
           }
         ]
       }
-      Transform {
-        translation 0 %{= -0.1016 - labelHeightMeters/2 }% 0.003
-        children [
-          Shape {
-            appearance PBRAppearance {
-              baseColorMap ImageTexture {
-                url [ %{= '"' .. context.temporary_files_path .. name .. i .. '.png"' }% ]
-              }
-              metalness 0
-              roughness 0.5
-            }
-            geometry Plane {
-              size %{= labelWidthMeters }% %{= labelHeightMeters }%
-            }
-            castShadows FALSE
-          }
-        ]
+      Text {
+        # Size is estimated to be 2in. x .75in.
+        size 0.0508 0.01905
+
+        # Image is offset by half the height of the AprilTag plus half the height of this label
+        translation 0 -0.111125 0.003
+
+        text %{= '"ID ' .. fields.aprilTagId.value .. '"' }%
+        font "Arial"
+        fontSize 60
+        dpi 72
       }
     ]
   }


### PR DESCRIPTION
* Common text generation code was moved into a shared proto (code was originally adapted from the webots docs)
* Instead of generating a new image per instance, it generates an image once per unique set of parameters
* This still shouldn't be used for vastly dynamic text, as it still generates a new image if the text changes

See below from top to bottom:
* AprilTagPanel (still looks fine)
* New bumper (text looks the same)
* Old bumper (in particular the metallic texture was removed)

![image](https://user-images.githubusercontent.com/4064932/211220727-ae039c7a-4548-4e2b-8b5c-0da6593778be.png)
